### PR TITLE
"use" the "check" and "ejson" packages (necessary for Meteor 1.2 support)

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,7 @@ Package.onUse(function(api) {
 
   //Required core packages
   api.use([
+    'check',
     'mongo',
     'underscore',
   ], 'server');
@@ -38,7 +39,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use('tinytest');
-  api.use(['mongo', 'autopublish', 'insecure', 'underscore']);
+  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore']);
 
   //Weak 3rd party packages
   api.use([

--- a/package.js
+++ b/package.js
@@ -14,6 +14,7 @@ Package.onUse(function(api) {
     'check',
     'mongo',
     'underscore',
+    'ejson'
   ], 'server');
 
   //Required 3rd party packages
@@ -39,7 +40,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use('tinytest');
-  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore']);
+  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore', 'ejson']);
 
   //Weak 3rd party packages
   api.use([


### PR DESCRIPTION
Currently this package does not work under Meteor 1.2 because `check` is no longer included automatically in Meteor 1.2.  This adds `check` to the required packages.
