### PR TITLE
Fix support for nested fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+/DENORMALIZE.sublime-project
+
+/DENORMALIZE.sublime-workspace

--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "from": "lodash@4.17.4"
+    }
+  }
+}

--- a/denormalize-common.js
+++ b/denormalize-common.js
@@ -8,6 +8,11 @@ Denormalize = {};
  */
 Denormalize.debug = false;
 
+if(Meteor.isServer){
+	_DenormalizeCache = new Mongo.Collection('_denormalizeCache');
+}
+
+
 debug = function() {
 	if(Denormalize.debug) console.log.apply(this, arguments);
 };
@@ -34,6 +39,21 @@ getFieldNamesObject = function(fields, obj1, obj2) {
 	});
 	return result;
 }
+var updated = []
+autoUpdate = function(collection, args){
+	args = JSON.stringify(args)
+	Meteor.setTimeout(function(){
+		if(!_DenormalizeCache.findOne({args})){
+			if(updated.indexOf(collection._name) == -1){
+				updated.push(collection._name)
+				console.log('Updating cache:', collection._name)
+				Denormalize.runHooksNow(collection, {})
+			}
+			_DenormalizeCache.insert({args})
+		}
+	}, 1000)
+}
+	
 
 flattenFields = function(object, prefix){
 	prefix = prefix || '';

--- a/denormalize-common.js
+++ b/denormalize-common.js
@@ -35,6 +35,19 @@ getFieldNamesObject = function(fields, obj1, obj2) {
 	return result;
 }
 
+flattenFields = function(object, prefix){
+	prefix = prefix || '';
+	var fields = [];
+	_.each(object, (val, key) => {
+		if(typeof val == 'object'){
+			fields = _.union(fields, flattenFields(val, prefix + key + '.'));
+		} else {
+			fields.push(prefix + key);
+		}
+	})
+	return fields;
+}
+
 /**
  * @method Denormalize.fieldsJoiner
  * @private

--- a/denormalize-common.js
+++ b/denormalize-common.js
@@ -1,4 +1,6 @@
-Denormalize = {};
+import _ from 'lodash'
+
+Denormalize = {}
 
 /**
  * @property Denormalize.debug
@@ -6,40 +8,29 @@ Denormalize = {};
  *
  * Set to `true` to show debug messages.
  */
-Denormalize.debug = false;
+Denormalize.debug = false
 
 if(Meteor.isServer){
-	_DenormalizeCache = new Mongo.Collection('_denormalizeCache');
+	_DenormalizeCache = new Mongo.Collection('_denormalizeCache')
 }
 
 
 debug = function() {
-	if(Denormalize.debug) console.log.apply(this, arguments);
-};
-
-changedFields = function(fields, doc1, doc2) {
-	return _.filter(fields, function(field) {
-		return Denormalize.getProp(doc1, field) !== Denormalize.getProp(doc2, field);
-	});
+	if(Denormalize.debug) console.log.apply(this, arguments)
 }
 
-object = function(key, value) {
-	var result = {};
-	result[key] = value;
-	return result;
-}
 
 getFieldNamesObject = function(fields, obj1, obj2) {
-	var result = {};
+	let result = {}
 	_.each(fields, function(field) {
-		var newValue = Denormalize.getProp(obj1, field);
-		if(newValue !== Denormalize.getProp(obj2, field)) {
-			result[field] = newValue;
+		let newValue = _.get(obj1, field)
+		if(newValue !== _.get(obj2, field)) {
+			result[field] = newValue
 		}
-	});
-	return result;
+	})
+	return result
 }
-var updated = []
+let updated = []
 autoUpdate = function(collection, args){
 	args = JSON.stringify(args)
 	Meteor.setTimeout(function(){
@@ -50,118 +41,89 @@ autoUpdate = function(collection, args){
 				Denormalize.runHooksNow(collection, {})
 			}
 			_DenormalizeCache.insert({args})
+		} else {
+			Denormalize.runHooksNow(collection, {})
 		}
 	}, 1000)
 }
 	
 
 flattenFields = function(object, prefix){
-	prefix = prefix || '';
-	var fields = [];
+	prefix = prefix || ''
+	let fields = []
 	_.each(object, (val, key) => {
 		if(typeof val == 'object'){
-			fields = _.union(fields, flattenFields(val, prefix + key + '.'));
+			fields = _.union(fields, flattenFields(val, prefix + key + '.'))
 		} else {
-			fields.push(prefix + key);
+			fields.push(prefix + key)
 		}
 	})
-	return fields;
-}
-
-/**
- * @method Denormalize.fieldsJoiner
- * @private
- * @param {String[]} fields An array of the fields that should be concatenated
- * @param {String} glue A string that will be used as glue in the concatenation. Defaults to `', '`
- * @returns {Function} A callback that can be used in `collection.cacheField()`
- *
- * Generates a callback that can be used in `collection.cacheField()`. The value will be a concatenation of the fields using `glue`.
- */
-Denormalize.fieldsJoiner = function(fields, glue) {
-	if(!Match.test(glue, String)) {
-		glue = ', ';
-	}
-	return function(doc, watchedFields) {
-		if(fields === undefined) fields = watchedFields;
-		return _.compact(_.map(fields, function(field) {
-			return getProp(doc, field);
-		})).join(glue);
-	}
-}
-
-Denormalize.getRealCollection = getRealCollection = function(collection, validate) {
-	return !validate && Package['aldeed:collection2'] ? collection._collection : collection;
+	return fields
 }
 
 Denormalize.getProp = getProp = function(obj, fields, returnObject) {
 	if(_.isString(fields)) {
-		var field = fields;
+		let field = fields
 		if(returnObject) {
-			var result = {};
-			result[field] = getProp(obj, field);
-			return result;
+			let result = {}
+			result[field] = getProp(obj, field)
+			return result
 		} else {
 			return _.reduce(field.split('.'), function(value, key) {
 				if (_.isObject(value) && _.isFunction(value[key])) {
-					return value[key]();
+					return value[key]()
 				} else if (_.isObject(value) && !_.isUndefined(value[key])) {
-					return value[key];
+					return value[key]
 				} else {
-					return;
+					return
 				}
-			}, obj);
+			}, obj)
 		}
 	} else if(_.isArray(fields)) {
 		if(returnObject) {
-			return setProps({}, _.object(fields, getProp(obj, fields)));
+			return setProps({}, _.object(fields, getProp(obj, fields)))
 		} else {
 			return _.map(fields, function(field) {
-				return getProp(obj, field);
-			});
+				return getProp(obj, field)
+			})
 		}
 	}
-};
+}
 
 Denormalize.setProps = setProps = function(destination) {
 	_.each(_.rest(arguments), function(obj) {
 		_.each(obj, function(value, key) {
-			var keys = key.split('.');
-			var lastKey = keys.pop();
-			var context = _.reduce(keys, function(context, key) {
-				return context[key] = context[key] || {};
-			}, destination);
-			context[lastKey] = value;
-		});
-	});
-	return destination;
-};
-
-Denormalize.haveDiffFieldValues = haveDiffFieldValues = function(fields, doc1, doc2) {
-	return !!_.find(fields, function(field) {
-		return Denormalize.getProp(doc1, field) !== Denormalize.getProp(doc2, field);
-	});
+			let keys = key.split('.')
+			let lastKey = keys.pop()
+			let context = _.reduce(keys, function(context, key) {
+				return context[key] = context[key] || {}
+			}, destination)
+			context[lastKey] = value
+		})
+	})
+	return destination
 }
 
 Denormalize.runHooksNow = function(collection, selector) {
-	var selector = selector || {};
-	if(!collection._denormalize) return;
+	selector = selector || {}
+	if(!collection._denormalize) return
 
 	collection.find(selector).forEach(function(doc) {
-		var topLevelFieldNames = _.keys(doc);
+		let topLevelFieldNames = _.keys(doc)
 
-		var currentRun = new DenormalizeRun();
+		let currentRun = new DenormalizeRun()
 
 		_.each(collection._denormalize.insert.hooks, function(hook) {
 
-			var fieldValues = getFieldNamesObject(hook.watchedFields, doc, {});
+			let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
 
-			var context = new DenormalizeHookContext({
+			let context = new DenormalizeHookContext({
 				fieldValues: fieldValues,
 				doc: doc,
-			}, currentRun);
-			hook.callback.call(context, fieldValues, doc);
-		});
+			}, currentRun)
+			hook.callback.call(context, fieldValues, doc)
+		})
 
-		currentRun.commit();
-	});
+		currentRun.commit()
+	})
 }

--- a/denormalize-common.js
+++ b/denormalize-common.js
@@ -20,7 +20,7 @@ debug = function() {
 }
 
 
-getFieldNamesObject = function(fields, obj1, obj2) {
+getDiff = function(fields, obj1, obj2) {
 	let result = {}
 	_.each(fields, function(field) {
 		let newValue = _.get(obj1, field)
@@ -31,6 +31,7 @@ getFieldNamesObject = function(fields, obj1, obj2) {
 	return result
 }
 let updated = []
+
 autoUpdate = function(collection, args){
 	args = JSON.stringify(args)
 	Meteor.setTimeout(function(){
@@ -61,49 +62,6 @@ flattenFields = function(object, prefix){
 	return fields
 }
 
-Denormalize.getProp = getProp = function(obj, fields, returnObject) {
-	if(_.isString(fields)) {
-		let field = fields
-		if(returnObject) {
-			let result = {}
-			result[field] = getProp(obj, field)
-			return result
-		} else {
-			return _.reduce(field.split('.'), function(value, key) {
-				if (_.isObject(value) && _.isFunction(value[key])) {
-					return value[key]()
-				} else if (_.isObject(value) && !_.isUndefined(value[key])) {
-					return value[key]
-				} else {
-					return
-				}
-			}, obj)
-		}
-	} else if(_.isArray(fields)) {
-		if(returnObject) {
-			return setProps({}, _.object(fields, getProp(obj, fields)))
-		} else {
-			return _.map(fields, function(field) {
-				return getProp(obj, field)
-			})
-		}
-	}
-}
-
-Denormalize.setProps = setProps = function(destination) {
-	_.each(_.rest(arguments), function(obj) {
-		_.each(obj, function(value, key) {
-			let keys = key.split('.')
-			let lastKey = keys.pop()
-			let context = _.reduce(keys, function(context, key) {
-				return context[key] = context[key] || {}
-			}, destination)
-			context[lastKey] = value
-		})
-	})
-	return destination
-}
-
 Denormalize.runHooksNow = function(collection, selector) {
 	selector = selector || {}
 	if(!collection._denormalize) return
@@ -115,7 +73,7 @@ Denormalize.runHooksNow = function(collection, selector) {
 
 		_.each(collection._denormalize.insert.hooks, function(hook) {
 
-			let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
+			let fieldValues = getDiff(hook.watchedFields, doc, {})
 
 			let context = new DenormalizeHookContext({
 				fieldValues: fieldValues,

--- a/denormalize-hooks.js
+++ b/denormalize-hooks.js
@@ -72,6 +72,9 @@ DenormalizeRun.prototype.commit = function() {
 				modifier.$unset = $unset
 			}
 			if(_.size(modifier)) {
+				debug('UPDATE ' + collection._name.toUpperCase())
+				debug('selector:', selector)
+				debug('modifier:', modifier)
 				collection.update(selector, modifier, {multi: true})
 			}
 		})

--- a/denormalize-hooks.js
+++ b/denormalize-hooks.js
@@ -1,111 +1,103 @@
-var collections = {};
+import _ from 'lodash'
+let collections = {}
 
-var lastCollectionId = 0;
+let lastCollectionId = 0
 
 DenormalizeRun = function() {
-	this._set = {};
+	this._set = {}
 }
 DenormalizeRun.prototype.set = function(collection, selector, fieldValues) {
 	if(!collection._denormalizeId) {
-		collection._denormalizeId = String(++lastCollectionId);
-		collections[collection._denormalizeId] = collection;
+		collection._denormalizeId = String(++lastCollectionId)
+		collections[collection._denormalizeId] = collection
 	}
 	if(_.isString(selector)) {
-		selector = {_id: selector};
+		selector = {_id: selector}
 	}
-	selector = EJSON.stringify(selector);
+	selector = EJSON.stringify(selector)
 	if(!this._set[collection._denormalizeId]) {
-		this._set[collection._denormalizeId] = {};
+		this._set[collection._denormalizeId] = {}
 	}
 	if(this._set[collection._denormalizeId][selector]) {
-		_.extend(this._set[collection._denormalizeId][selector], fieldValues);
+		_.extend(this._set[collection._denormalizeId][selector], fieldValues)
 	} else {
-		this._set[collection._denormalizeId][selector] = fieldValues;
+		this._set[collection._denormalizeId][selector] = fieldValues
 	}
 }
 DenormalizeRun.prototype.unset = function(collection, selector, fields) {
-	var self = this;
+	let self = this
 	if(!collection._denormalizeId) {
-		collection._denormalizeId = String(++lastCollectionId);
-		collections[collection._denormalizeId] = collection;
+		collection._denormalizeId = String(++lastCollectionId)
+		collections[collection._denormalizeId] = collection
 	}
 	if(_.isString(selector)) {
-		selector = {_id: selector};
+		selector = {_id: selector}
 	}
-	selector = EJSON.stringify(selector);
+	selector = EJSON.stringify(selector)
 	if(!self._set[collection._denormalizeId]) {
-		self._set[collection._denormalizeId] = {};
+		self._set[collection._denormalizeId] = {}
 	}
 	if(!self._set[collection._denormalizeId][selector]) {
-		self._set[collection._denormalizeId][selector] = {};
+		self._set[collection._denormalizeId][selector] = {}
 	}
 	_.each(fields, function(field) {
-		self._set[collection._denormalizeId][selector][field] = undefined;
-	});
+		self._set[collection._denormalizeId][selector][field] = undefined
+	})
 }
-function set(object, path, value){
-	if(path.indexOf('.') > -1){
-		var key = path.slice(0, path.indexOf('.'));
-		if(!object[key]) object[key] = {};
-		path = path.slice(path.indexOf('.') + 1);
-		set(object[key], path, value);
-	} else {
-		object[path] = value;
-	}
-}
+
 DenormalizeRun.prototype.commit = function() {
-	if(this.isCommitted) return;
+	if(this.isCommitted) return
 	_.each(this._set, function(docs, collectionId) {
-		collection = collections[collectionId];
+		collection = collections[collectionId]
 		_.each(docs, function(fieldValues, selector) {
-			selector = EJSON.parse(selector);
-			var modifier = {};
-			var $set = {};
-			var $unset = {};
+			selector = EJSON.parse(selector)
+			let modifier = {}
+			let $set = {}
+			let $unset = {}
 			_.each(fieldValues, function(value, field) {
 				if(typeof value == 'object'){
 					_.each(value, (val, key) => {
-						set($set, field + '.' + key, val);
+						_.set($set, field + '.' + key, val)
 					})
 				} else if(value === undefined) {
-					$unset[field] = 1;
+					$unset[field] = 1
 				} else {
-					$set[field] = value;
+					$set[field] = value
 				}
 			})
 			if(_.size($set)) {
-				modifier.$set = $set;
+				modifier.$set = $set
 			}
 			if(_.size($unset)) {
-				modifier.$unset = $unset;
+				modifier.$unset = $unset
 			}
 			if(_.size(modifier)) {
-				collection.update(selector, modifier, {multi: true});
+				collection.update(selector, modifier, {multi: true})
 			}
-		});
-	});
-	this.isCommitted = true;
-};
+		})
+	})
+	this.isCommitted = true
+}
 
 DenormalizeHookContext = function(data, currentRun) {
-	_.extend(this, data);
-	this._currentRun = currentRun;
+	_.extend(this, data)
+	this._currentRun = currentRun
 }
 
 DenormalizeHookContext.prototype.set = function(collection, selector, fieldValues) {
-	this._currentRun.set(collection, selector, fieldValues);
+	this._currentRun.set(collection, selector, fieldValues)
 }
 DenormalizeHookContext.prototype.unset = function(collection, selector, fields) {
 	if(_.isString(fields)) {
-		fields = [fields];
+		fields = [fields]
 	} else if(_.isObject(fields) && !_.isArray(fields)) {
-		fields = _.keys(fields);
+		fields = _.keys(fields)
 	}
-	this._currentRun.unset(collection, selector, fields);
+	this._currentRun.unset(collection, selector, fields)
 }
 
 ensureDenormalize = function(collection) {
-	if(collection._denormalize) return;
+	if(collection._denormalize) return
 	collection._denormalize = {
 		insert: {
 			watchedTopLevelFields: [],
@@ -124,127 +116,127 @@ ensureDenormalize = function(collection) {
 		},
 	}
 	collection.after.insert(function(userId, doc) {
-		var topLevelFieldNames = _.keys(doc);
+		let topLevelFieldNames = _.keys(doc)
 
-		var currentRun = new DenormalizeRun();
+		let currentRun = new DenormalizeRun()
 
 		Meteor.defer(function() {
 			_.each(collection._denormalize.insert.hooks, function(hook) {
 
-				var fieldValues = getFieldNamesObject(hook.watchedFields, doc, {});
+				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
 
-				var context = new DenormalizeHookContext({
+				let context = new DenormalizeHookContext({
 					fieldValues: fieldValues,
 					doc: doc,
-				}, currentRun);
-				hook.callback.call(context, fieldValues, doc);
-			});
-			currentRun.commit();
-		});
-	});
+				}, currentRun)
+				hook.callback.call(context, fieldValues, doc)
+			})
+			currentRun.commit()
+		})
+	})
 	collection.after.update(function(userId, doc, topLevelFieldNames) {
-		var oldDoc = this.previous;
+		let oldDoc = this.previous
 
 		// Drop out if none of topLevelFieldNames are in watchedTopLevelFields
-		if(_.intersection(collection._denormalize.update.watchedTopLevelFields, topLevelFieldNames).length == 0) return;
+		if(_.intersection(collection._denormalize.update.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-		var currentRun = new DenormalizeRun();
+		let currentRun = new DenormalizeRun()
 
 		Meteor.defer(function() {
 			_.each(collection._denormalize.update.hooks, function(hook) {
 				// Drop out if none of topLevelFieldNames are in watchedTopLevelFields of this hook
-				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return;
+				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-				var fieldValues = getFieldNamesObject(hook.watchedFields, doc, oldDoc);
+				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, oldDoc)
 
 				// Drop out if none of fieldValues are in watchedFields of this hook
-				if(_.size(fieldValues) == 0) return;
+				if(_.size(fieldValues) == 0) return
 
-				var oldFieldValues = getProp(oldDoc, _.keys(fieldValues), true);
+				let oldFieldValues = _.pick(oldDoc, _.keys(fieldValues))
 
-				var context = new DenormalizeHookContext({
+				let context = new DenormalizeHookContext({
 					fieldValues: fieldValues,
 					doc: doc,
 					oldFieldValues: oldFieldValues,
 					oldDoc: oldDoc,
-				}, currentRun);
-				hook.callback.call(context, fieldValues, doc, oldFieldValues, oldDoc);
-			});
-			currentRun.commit();
-		});
-	});
+				}, currentRun)
+				hook.callback.call(context, fieldValues, doc, oldFieldValues, oldDoc)
+			})
+			currentRun.commit()
+		})
+	})
 	collection.after.remove(function(userId, doc) {
-		var topLevelFieldNames = _.keys(doc);
+		let topLevelFieldNames = _.keys(doc)
 
 		// Drop out if none of topLevelFieldNames are in watchedTopLevelFields
-		if(_.intersection(collection._denormalize.remove.watchedTopLevelFields, topLevelFieldNames).length == 0) return;
+		if(_.intersection(collection._denormalize.remove.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-		var currentRun = new DenormalizeRun();
+		let currentRun = new DenormalizeRun()
 
 		Meteor.defer(function() {
 			_.each(collection._denormalize.remove.hooks, function(hook) {
 				// Drop out if none of topLevelFieldNames are in watchedTopLevelFields of this hook
-				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return;
+				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-				var fieldValues = getFieldNamesObject(hook.watchedFields, doc, {});
+				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
 
 				// Drop out if none of fieldValues are in watchedFields of this hook
-				if(_.size(fieldValues) == 0) return;
+				if(_.size(fieldValues) == 0) return
 
-				var context = new DenormalizeHookContext({
+				let context = new DenormalizeHookContext({
 					fieldValues: fieldValues,
 					doc: doc,
-				}, currentRun);
-				hook.callback.call(context, fieldValues, doc);
-			});
-			currentRun.commit();
-		});
-	});
+				}, currentRun)
+				hook.callback.call(context, fieldValues, doc)
+			})
+			currentRun.commit()
+		})
+	})
 }
 
 topLevelFields = function(fields) {
 	return _.uniq(_.map(fields, function(field) {
-		return field.replace(/\..*$/, '');
-	}));
+		return field.replace(/\..*$/, '')
+	}))
 }
 
-var lastHookId = 0;
+let lastHookId = 0
 makeHookId = function() {
-	return String(++lastHookId);
+	return String(++lastHookId)
 }
 
 Denormalize.addHooks = function(collection, watchedFields, hooks) {
 	//collection must be a Mongo.Collection
-	check(collection, Mongo.Collection);
+	check(collection, Mongo.Collection)
 
 	//watchedFields must be a nonempty array of strings
-	check(watchedFields, [String]);
-	if(watchedFields.length == 0) return;
+	check(watchedFields, [String])
+	if(watchedFields.length == 0) return
 
 	//hooks must be a nonempty object with insert, update and/or remove.
 	check(hooks, {
 		insert: Match.Optional(Function),
 		update: Match.Optional(Function),
 		remove: Match.Optional(Function),
-	});
-	if(_.size(hooks) == 0) return;
+	})
+	if(_.size(hooks) == 0) return
 
-	ensureDenormalize(collection);
+	ensureDenormalize(collection)
 
-	var watchedTopLevelFields = topLevelFields(watchedFields);
+	let watchedTopLevelFields = topLevelFields(watchedFields)
 
-	var hookId = makeHookId();
+	let hookId = makeHookId()
 
 	_.each(hooks, function(callback, hookName) {
-		var store = collection._denormalize[hookName];
-		store.watchedTopLevelFields = _.union(store.watchedTopLevelFields, watchedTopLevelFields);
-		store.watchedFields = _.union(store.watchedFields, watchedFields);
+		let store = collection._denormalize[hookName]
+		store.watchedTopLevelFields = _.union(store.watchedTopLevelFields, watchedTopLevelFields)
+		store.watchedFields = _.union(store.watchedFields, watchedFields)
 		store.hooks[hookId] = {
 			callback: callback,
 			_id: hookId,
 			watchedFields: watchedFields,
 			watchedTopLevelFields: watchedTopLevelFields,
-		};
-	});
+		}
+	})
 
 }

--- a/denormalize-hooks.js
+++ b/denormalize-hooks.js
@@ -43,6 +43,16 @@ DenormalizeRun.prototype.unset = function(collection, selector, fields) {
 		self._set[collection._denormalizeId][selector][field] = undefined;
 	});
 }
+function set(object, path, value){
+	if(path.indexOf('.') > -1){
+		var key = path.slice(0, path.indexOf('.'));
+		if(!object[key]) object[key] = {};
+		path = path.slice(path.indexOf('.') + 1);
+		set(object[key], path, value);
+	} else {
+		object[path] = value;
+	}
+}
 DenormalizeRun.prototype.commit = function() {
 	if(this.isCommitted) return;
 	_.each(this._set, function(docs, collectionId) {
@@ -53,7 +63,11 @@ DenormalizeRun.prototype.commit = function() {
 			var $set = {};
 			var $unset = {};
 			_.each(fieldValues, function(value, field) {
-				if(value === undefined) {
+				if(typeof value == 'object'){
+					_.each(value, (val, key) => {
+						set($set, key, val);
+					})
+				} else if(value === undefined) {
 					$unset[field] = 1;
 				} else {
 					$set[field] = value;

--- a/denormalize-hooks.js
+++ b/denormalize-hooks.js
@@ -123,7 +123,7 @@ ensureDenormalize = function(collection) {
 		Meteor.defer(function() {
 			_.each(collection._denormalize.insert.hooks, function(hook) {
 
-				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
+				let fieldValues = getDiff(hook.watchedFields, doc, {})
 
 				let context = new DenormalizeHookContext({
 					fieldValues: fieldValues,
@@ -147,7 +147,7 @@ ensureDenormalize = function(collection) {
 				// Drop out if none of topLevelFieldNames are in watchedTopLevelFields of this hook
 				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, oldDoc)
+				let fieldValues = getDiff(hook.watchedFields, doc, oldDoc)
 
 				// Drop out if none of fieldValues are in watchedFields of this hook
 				if(_.size(fieldValues) == 0) return
@@ -178,7 +178,7 @@ ensureDenormalize = function(collection) {
 				// Drop out if none of topLevelFieldNames are in watchedTopLevelFields of this hook
 				if(_.intersection(hook.watchedTopLevelFields, topLevelFieldNames).length == 0) return
 
-				let fieldValues = getFieldNamesObject(hook.watchedFields, doc, {})
+				let fieldValues = getDiff(hook.watchedFields, doc, {})
 
 				// Drop out if none of fieldValues are in watchedFields of this hook
 				if(_.size(fieldValues) == 0) return

--- a/denormalize-hooks.js
+++ b/denormalize-hooks.js
@@ -65,7 +65,7 @@ DenormalizeRun.prototype.commit = function() {
 			_.each(fieldValues, function(value, field) {
 				if(typeof value == 'object'){
 					_.each(value, (val, key) => {
-						set($set, key, val);
+						set($set, field + '.' + key, val);
 					})
 				} else if(value === undefined) {
 					$unset[field] = 1;

--- a/denormalize-tests-server.js
+++ b/denormalize-tests-server.js
@@ -1,16 +1,16 @@
-var speed = 200;
+var speed = 200
 
-Posts = new Mongo.Collection('posts');
-Comments = new Mongo.Collection('comments');
-Denormalize.debug = true;
+Posts = new Mongo.Collection('posts')
+Comments = new Mongo.Collection('comments')
+Denormalize.debug = true
 
 /*
 collection.cacheDoc()
 */
 
 Tinytest.add("cacheDoc: Comments.cacheDoc('post', Posts, ['title'])", function(test) {
-	Posts.remove({});
-	Comments.remove({});
+	Posts.remove({})
+	Comments.remove({})
 	Comments.attachSchema(new SimpleSchema({
 		_id: {
 			type: String,
@@ -24,206 +24,206 @@ Tinytest.add("cacheDoc: Comments.cacheDoc('post', Posts, ['title'])", function(t
 			type: String,
 			optional: true,
 		},
-	}));
-	Comments.cacheDoc('post', Posts, ['title']);
-});
+	}))
+	Comments.cacheDoc('post', Posts, ['title'])
+})
 
 Tinytest.addAsync("cacheDoc: Insert comment", function(test, next) {
 	Comments.insert({
 		_id: 'comment1',
 		post_id: 'post1',
 		content: 'Great post!',
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Comments.findOne('comment1')._post, undefined);
-		next();
-	}, speed);
-});
+		test.equal(Comments.findOne('comment1')._post, undefined)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheDoc: Insert post", function(test, next) {
 	Posts.insert({
 		_id: 'post1',
 		title: 'My first post',
 		content: 'This is my first post'
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.notEqual(Comments.findOne('comment1')._post, undefined);
-		test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title);
-		next();
-	}, speed);
-});
+		test.notEqual(Comments.findOne('comment1')._post, undefined)
+		test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheDoc: Insert another comment", function(test, next) {
 	Comments.insert({
 		_id: 'comment2',
 		post_id: 'post1',
 		content: 'Love it!',
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.notEqual(Comments.findOne('comment2')._post, undefined);
-		test.equal(Comments.findOne('comment2')._post.title, Posts.findOne('post1').title);
-		next();
-	}, speed);
-});
+		test.notEqual(Comments.findOne('comment2')._post, undefined)
+		test.equal(Comments.findOne('comment2')._post.title, Posts.findOne('post1').title)
+		next()
+	}, speed)
+})
 
 Tinytest.add("cacheDoc: Collection helper", function(test) {
-	test.equal(Comments.findOne('comment1').post().title, Posts.findOne('post1').title);
-});
+	test.equal(Comments.findOne('comment1').post().title, Posts.findOne('post1').title)
+})
 
 Tinytest.addAsync("cacheDoc: Update post title", function(test, next) {
 	Posts.update('post1', {$set: {
 		title: 'Not my first post',
-	}});
+	}})
 	Meteor.setTimeout(function() {
-		test.notEqual(Comments.findOne('comment1')._post, undefined);
-		test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title);
-		next();
-	}, speed);
-});
+		test.notEqual(Comments.findOne('comment1')._post, undefined)
+		test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheDoc: Update comment post_id", function(test, next) {
 	Comments.update('comment1', {$set: {
 		post_id: 'post2',
-	}});
+	}})
 	Meteor.setTimeout(function() {
-		test.equal(Comments.findOne('comment1')._post, undefined);
+		test.equal(Comments.findOne('comment1')._post, undefined)
 		//reset:
 		Comments.update('comment1', {$set: {
 			post_id: 'post1',
-		}});
+		}})
 		Meteor.setTimeout(function() {
-			test.notEqual(Comments.findOne('comment1')._post, undefined);
-			test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title);
-			next();
-		}, speed);
-	}, speed);
-});
+			test.notEqual(Comments.findOne('comment1')._post, undefined)
+			test.equal(Comments.findOne('comment1')._post.title, Posts.findOne('post1').title)
+			next()
+		}, speed)
+	}, speed)
+})
 
 Tinytest.addAsync("cacheDoc: Remove post", function(test, next) {
-	Posts.remove('post1');
+	Posts.remove('post1')
 	Meteor.setTimeout(function() {
-		test.equal(Comments.findOne('comment1')._post, undefined);
-		next();
-	}, speed);
-});
+		test.equal(Comments.findOne('comment1')._post, undefined)
+		next()
+	}, speed)
+})
 
 /*
 collection.cacheCount()
 */
 
 Tinytest.add("cacheCount: Posts.cacheCount('commentsCount', Comments, 'post_id')", function(test) {
-	Posts.remove({});
-	Comments.remove({});
-	Posts.cacheCount('commentsCount', Comments, 'post_id');
-});
+	Posts.remove({})
+	Comments.remove({})
+	Posts.cacheCount('commentsCount', Comments, 'post_id')
+})
 
 Tinytest.addAsync("cacheCount: Insert comment", function(test, next) {
 	Comments.insert({
 		_id: 'comment1',
 		post_id: 'post1',
 		content: 'Great post!',
-	});
+	})
 	Posts.insert({
 		_id: 'post1',
 		title: 'My first post',
 		content: 'This is my first post'
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1').commentsCount, 1);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1').commentsCount, 1)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheCount: Insert comment again", function(test, next) {
 	Comments.insert({
 		_id: 'comment2',
 		post_id: 'post1',
 		content: 'Love it!',
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1').commentsCount, 2);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1').commentsCount, 2)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheCount: Insert comment on other post", function(test, next) {
 	Comments.insert({
 		_id: 'comment3',
 		post_id: 'post2',
 		content: 'Love it!',
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1').commentsCount, 2);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1').commentsCount, 2)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheCount: Remove comment", function(test, next) {
-	Comments.remove('comment2');
+	Comments.remove('comment2')
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1').commentsCount, 1);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1').commentsCount, 1)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheCount: Update comment post_id", function(test, next) {
-	Comments.update('comment1', {$set: {post_id: 'post2'}});
+	Comments.update('comment1', {$set: {post_id: 'post2'}})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1').commentsCount, 0);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1').commentsCount, 0)
+		next()
+	}, speed)
+})
 
 /*
 collection.cacheField()
 */
 
 Tinytest.add("cacheField: Posts.cacheField('_text', ['title', 'content'])", function(test) {
-	Posts.remove({});
-	Comments.remove({});
-	Posts.cacheField('_text', ['title', 'content']);
-});
+	Posts.remove({})
+	Comments.remove({})
+	Posts.cacheField('_text', ['title', 'content'])
+})
 
 Tinytest.addAsync("cacheField: Insert post", function(test, next) {
 	Posts.insert({
 		_id: 'post1',
 		title: 'ABC',
 		content: 'DEF'
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post1')._text, 'ABC, DEF');
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post1')._text, 'ABC, DEF')
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheField: value callback doc", function(test, next) {
 	Posts.cacheField('_doc', ['title', 'content'], function(doc, fields) {
-		return doc;
-	});
+		return doc
+	})
 	Posts.insert({
 		_id: 'post2',
 		title: 'ABC',
 		content: 'DEF'
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post2')._doc._id, Posts.findOne('post2')._id);
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post2')._doc._id, Posts.findOne('post2')._id)
+		next()
+	}, speed)
+})
 
 Tinytest.addAsync("cacheField: value callback fields", function(test, next) {
 	Posts.cacheField('_fields', ['title', 'content'], function(doc, fields) {
-		return fields.join(',');
-	});
+		return fields.join(',')
+	})
 	Posts.insert({
 		_id: 'post3',
 		title: 'ABC',
 		content: 'DEF'
-	});
+	})
 	Meteor.setTimeout(function() {
-		test.equal(Posts.findOne('post3')._fields, 'title,content');
-		next();
-	}, speed);
-});
+		test.equal(Posts.findOne('post3')._fields, 'title,content')
+		next()
+	}, speed)
+})
 
 

--- a/methods/cacheCount.js
+++ b/methods/cacheCount.js
@@ -9,9 +9,9 @@ import _ from 'lodash'
  *
  * When a document in the target collection is inserted/updated/removed this denormalization updates the count on the references document in the main collection. The reference field is on the target collection.
  */
-Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referenceField, options) {
+Mongo.Collection.prototype.cacheCount = function(cacheField, childCollection, referenceField, options) {
 	check(cacheField, String)
-	check(collection, Mongo.Collection)
+	check(childCollection, Mongo.Collection)
 	check(referenceField, String)
 
 	if(!Match.test(options, Object)) {
@@ -28,40 +28,39 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 		selector: Object
 	})
 
+	let parentCollection = this
 	let validate = options.validate
-	let collection1 = this
-	let collection2 = collection
 	let selector = options.selector
 	let watchedFields = _.union([referenceField], _.keys(selector))
 
-	Denormalize.addHooks(collection1, ['_id'], {
+	Denormalize.addHooks(parentCollection, ['_id'], {
 		//Update the count on the main collection after insert
 		insert: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheCount')
-			debug(collection1._name+'.after.insert', doc._id)
+			debug('\n'+parentCollection._name+'.cacheCount')
+			debug(parentCollection._name+'.after.insert', doc._id)
 			let select = {[referenceField]:doc._id}
 			if(selector){
 				_.extend(select, selector)
 			}
-			this.set(collection1, {_id: doc._id}, {[cacheField]:collection2.find(select).count()})
+			this.set(parentCollection, {_id: doc._id}, {[cacheField]:childCollection.find(select).count()})
 		},
 	})
 
-	Denormalize.addHooks(collection2, watchedFields, {
+	Denormalize.addHooks(childCollection, watchedFields, {
 		//Unset the count when a referencing doc in target collection is inserted
 		insert: function(fieldValues, doc) {
 			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheCount')
-			debug(collection2._name+'.after.insert', doc._id)
+			debug('\n'+parentCollection._name+'.cacheCount')
+			debug(childCollection._name+'.after.insert', doc._id)
 			debug('referenceField value:', referenceFieldValue)
 
 			let select = {[referenceField]:referenceFieldValue}
 			if(selector){
 				_.extend(select, selector)
 			}
-			this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
+			this.set(parentCollection, {_id: referenceFieldValue}, {[cacheField]:childCollection.find(select).count()})
 		},
 
 		//Unset the count(s) when a referencing doc in target collection changes
@@ -69,8 +68,8 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 			let referenceFieldValue = fieldValues[referenceField]
 			let oldReferenceFieldValue = oldFieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection2._name+'.after.update', doc._id)
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(childCollection._name+'.after.update', doc._id)
 			debug('referenceField value:', referenceFieldValue)
 			debug('referenceField previous value:', oldReferenceFieldValue)
 
@@ -82,10 +81,10 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 				_.extend(select, selector)
 			}
 			if(referenceFieldValue) {
-				this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
+				this.set(parentCollection, {_id: referenceFieldValue}, {[cacheField]:childCollection.find(select).count()})
 			}
 			if(oldReferenceFieldValue) {
-				this.set(collection1, {_id: oldReferenceFieldValue}, {[cacheField]:collection2.find(select).count()})
+				this.set(parentCollection, {_id: oldReferenceFieldValue}, {[cacheField]:childCollection.find(select).count()})
 			}
 		},
 
@@ -93,8 +92,8 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 		remove: function(fieldValues, doc) {
 			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheCount')
-			debug(collection2._name+'.after.remove', doc._id)
+			debug('\n'+parentCollection._name+'.cacheCount')
+			debug(childCollection._name+'.after.remove', doc._id)
 			debug('referenceField value:', referenceFieldValue)
 
 			let select = {[referenceField]:referenceFieldValue}
@@ -103,10 +102,9 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 			}
 
 			if(referenceFieldValue) {
-				this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
+				this.set(parentCollection, {_id: referenceFieldValue}, {[cacheField]:childCollection.find(select).count()})
 			}
 		},
 	})
-
-	autoUpdate(collection, [this._name, cacheField, collection._name, referenceField, options])
+	autoUpdate(this, [cacheField, childCollection._name, referenceField, options])
 }

--- a/methods/cacheCount.js
+++ b/methods/cacheCount.js
@@ -114,4 +114,5 @@ Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referen
 		},
 	});
 
+	autoUpdate(collection, [this._name, cacheField, collection._name, referenceField, options])
 }

--- a/methods/cacheCount.js
+++ b/methods/cacheCount.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 /**
  * @method collection.cacheCount
  * @public
@@ -9,118 +10,103 @@
  * When a document in the target collection is inserted/updated/removed this denormalization updates the count on the references document in the main collection. The reference field is on the target collection.
  */
 Mongo.Collection.prototype.cacheCount = function(cacheField, collection, referenceField, options) {
-	check(cacheField, String);
-	check(collection, Mongo.Collection);
-	check(referenceField, String);
+	check(cacheField, String)
+	check(collection, Mongo.Collection)
+	check(referenceField, String)
 
 	if(!Match.test(options, Object)) {
-		options = {};
+		options = {}
 	}
 
 	_.defaults(options, {
 		validate: false,
 		selector: {}
-	});
+	})
 
 	check(options, {
 		validate: Boolean,
 		selector: Object
-	});
+	})
 
-	var validate = options.validate;
-	var collection1 = this;
-	var collection2 = collection;
-	var selector = options.selector;
-	var watchedFields = _.union([referenceField], _.keys(selector))
+	let validate = options.validate
+	let collection1 = this
+	let collection2 = collection
+	let selector = options.selector
+	let watchedFields = _.union([referenceField], _.keys(selector))
 
 	Denormalize.addHooks(collection1, ['_id'], {
 		//Update the count on the main collection after insert
 		insert: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheCount');
-			debug(collection1._name+'.after.insert', doc._id);
-			var select = object(referenceField, doc._id)
+			debug('\n'+collection1._name+'.cacheCount')
+			debug(collection1._name+'.after.insert', doc._id)
+			let select = {[referenceField]:doc._id}
 			if(selector){
 				_.extend(select, selector)
 			}
-			this.set(getRealCollection(collection1, validate), {_id: doc._id}, object(
-				cacheField,
-				collection2.find(select).count()
-			));
+			this.set(collection1, {_id: doc._id}, {[cacheField]:collection2.find(select).count()})
 		},
-	});
+	})
 
 	Denormalize.addHooks(collection2, watchedFields, {
 		//Unset the count when a referencing doc in target collection is inserted
 		insert: function(fieldValues, doc) {
-			var referenceFieldValue = fieldValues[referenceField];
+			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheCount');
-			debug(collection2._name+'.after.insert', doc._id);
-			debug('referenceField value:', referenceFieldValue);
+			debug('\n'+collection1._name+'.cacheCount')
+			debug(collection2._name+'.after.insert', doc._id)
+			debug('referenceField value:', referenceFieldValue)
 
-			var select = object(referenceField, referenceFieldValue)
+			let select = {[referenceField]:referenceFieldValue}
 			if(selector){
 				_.extend(select, selector)
 			}
-			this.set(getRealCollection(collection1, validate), {_id: referenceFieldValue}, object(
-				cacheField,
-				collection2.find(select).count()
-			));
+			this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
 		},
 
 		//Unset the count(s) when a referencing doc in target collection changes
 		update: function(fieldValues, doc, oldFieldValues, oldDoc) {
-			var referenceFieldValue = fieldValues[referenceField];
-			var oldReferenceFieldValue = oldFieldValues[referenceField];
+			let referenceFieldValue = fieldValues[referenceField]
+			let oldReferenceFieldValue = oldFieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection2._name+'.after.update', doc._id);
-			debug('referenceField value:', referenceFieldValue);
-			debug('referenceField previous value:', oldReferenceFieldValue);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection2._name+'.after.update', doc._id)
+			debug('referenceField value:', referenceFieldValue)
+			debug('referenceField previous value:', oldReferenceFieldValue)
 
 			if(_.intersection(_.keys(fieldValues), _.keys(selector))){
 				referenceFieldValue = doc[referenceField]
 			}
-			var select = object(referenceField, referenceFieldValue)
+			let select = {[referenceField]:referenceFieldValue}
 			if(selector){
 				_.extend(select, selector)
 			}
 			if(referenceFieldValue) {
-				this.set(getRealCollection(collection1, validate), {_id: referenceFieldValue}, object(
-					cacheField,
-					collection2.find(select).count()
-				));
+				this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
 			}
 			if(oldReferenceFieldValue) {
-				this.set(getRealCollection(collection1, validate), {_id: oldReferenceFieldValue}, object(
-					cacheField,
-					collection2.find(select).count()
-				));
+				this.set(collection1, {_id: oldReferenceFieldValue}, {[cacheField]:collection2.find(select).count()})
 			}
 		},
 
 		//Unset the count when a referencing doc in target collection is removed
 		remove: function(fieldValues, doc) {
-			var referenceFieldValue = fieldValues[referenceField];
+			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheCount');
-			debug(collection2._name+'.after.remove', doc._id);
-			debug('referenceField value:', referenceFieldValue);
+			debug('\n'+collection1._name+'.cacheCount')
+			debug(collection2._name+'.after.remove', doc._id)
+			debug('referenceField value:', referenceFieldValue)
 
-			var select = object(referenceField, referenceFieldValue)
+			let select = {[referenceField]:referenceFieldValue}
 			if(selector){
 				_.extend(select, selector)
 			}
 
 			if(referenceFieldValue) {
-				this.set(getRealCollection(collection1, validate), {_id: referenceFieldValue}, object(
-					cacheField,
-					collection2.find(select).count()
-				));
+				this.set(collection1, {_id: referenceFieldValue}, {[cacheField]:collection2.find(select).count()})
 			}
 		},
-	});
+	})
 
 	autoUpdate(collection, [this._name, cacheField, collection._name, referenceField, options])
 }

--- a/methods/cacheDoc.js
+++ b/methods/cacheDoc.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 /**
  * @method collection.cacheDoc
  * @public
@@ -14,11 +15,11 @@
  */
 Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options) {
 
-	check(name, String);
-	check(collection, Mongo.Collection);
+	check(name, String)
+	check(collection, Mongo.Collection)
 	Match.test(fields, Match.OneOf([String], Object))
 	if(!Match.test(options, Object)) {
-		options = {};
+		options = {}
 	}
 
 	if(Match.test(name, String)) {
@@ -26,115 +27,115 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 			cacheField: '_'+name,
 			referenceField: name+'_id',
 			helper: name,
-		});
+		})
 	}
 
 	if(Match.test(options, Match.ObjectIncluding({helper: Boolean})) && !options.helper) {
-		delete options.helper;
+		delete options.helper
 	}
 
 	_.defaults(options, {
 		validate: false,
-	});
+	})
 
 	check(options, {
 		cacheField: String,
 		referenceField: String,
 		helper: Match.Optional(String),
 		validate: Boolean,
-	});
+	})
 
-	var fieldsToCopy = typeof fields == 'array' ? fields : flattenFields(fields);
-	var cacheField = options.cacheField;
-	var referenceField = options.referenceField;
-	var collection1 = this;
-	var collection2 = collection;
-	var helper = options.helper;
-	var validate = options.validate;
+	let fieldsToCopy = _.isArray(fields) ? fields : flattenFields(fields)
+	let cacheField = options.cacheField
+	let referenceField = options.referenceField
+	let collection1 = this
+	let collection2 = collection
+	let helper = options.helper
+	let validate = options.validate
 
 	//Fields specifier for Mongo.Collection.find
-	var fieldsInFind = {_id: 0};
+	let fieldsInFind = {_id: 0}
 	_.each(fieldsToCopy, function(field) {
-		fieldsInFind[field] = 1;
-	});
+		fieldsInFind[field] = 1
+	})
 
 	//Collection helper
 	if(helper && Match.test(collection1.helpers, Function)) {
-		var helpers = {};
+		let helpers = {}
 		helpers[helper] = function() {
-			var fieldValue = Denormalize.getProp(this, referenceField);
-			return fieldValue && collection2.findOne(fieldValue);
-		};
-		collection1.helpers(helpers);
+			let fieldValue = _.get(this, referenceField)
+			return fieldValue && collection2.findOne(fieldValue)
+		}
+		collection1.helpers(helpers)
 	}
 
 	Denormalize.addHooks(collection1, [referenceField], {
 		//Update the cached field on the main collection after insert
 		insert: function(fieldValues, doc) {
-			var referenceFieldValue = fieldValues[referenceField];
+			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection1._name+'.after.insert', doc._id);
-			debug('referenceField value:', referenceFieldValue);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection1._name+'.after.insert', doc._id)
+			debug('referenceField value:', referenceFieldValue)
 
-			var doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind});
+			let doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
 			if(doc2) {
-				debug('$set');
-				this.set(getRealCollection(collection1, validate), doc._id, object(cacheField, doc2));
+				debug('$set')
+				this.set(collection1, doc._id, {[cacheField]:doc2})
 			} else {
-				debug('$unset');
+				debug('$unset')
 				// No unset needed
 			}
 		},
 
 		//Update the cached field on the main collection if the referenceField field is changed
 		update: function(fieldValues, doc) {
-			var referenceFieldValue = fieldValues[referenceField];
+			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection1._name+'.after.update', doc._id);
-			debug('referenceField value:', referenceFieldValue);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection1._name+'.after.update', doc._id)
+			debug('referenceField value:', referenceFieldValue)
 
-			var doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind});
+			let doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
 			if(doc2) {
-				debug('$set');
-				this.set(getRealCollection(collection1, validate), doc._id, object(cacheField, doc2));
+				debug('$set')
+				this.set(collection1, doc._id, {[cacheField]:doc2})
 			} else {
-				debug('$unset');
-				this.unset(getRealCollection(collection1, validate), doc._id, [cacheField]);
+				debug('$unset')
+				this.unset(collection1, doc._id, [cacheField])
 			}
 		},
-	});
+	})
 
 	Denormalize.addHooks(collection2, fieldsToCopy, {
 		//Update the cached field on the main collection if a matching doc on the target collection is inserted
 		insert: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection2._name+'.after.insert', doc._id);
-			debug('fields to copy:', fieldsToCopy);
-			debug('changed fields:', fieldValues);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection2._name+'.after.insert', doc._id)
+			debug('fields to copy:', fieldsToCopy)
+			debug('changed fields:', fieldValues)
 
-			this.set(getRealCollection(collection1, validate), object(referenceField, doc._id), object(cacheField, fieldValues));
+			this.set(collection1, {[referenceField]:doc._id}, {[cacheField]:fieldValues})
 		},
 
 		//Update the cached field on the main collection if the matching doc on the target collection is updated
 		update: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection2._name+'.after.update', doc._id);
-			debug('fields to copy:', fieldsToCopy);
-			debug('changed fields:', fieldValues);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection2._name+'.after.update', doc._id)
+			debug('fields to copy:', fieldsToCopy)
+			debug('changed fields:', fieldValues)
 
-			this.set(getRealCollection(collection1, validate), object(referenceField, doc._id), object(cacheField, fieldValues));
+			this.set(collection1, {[referenceField]:doc._id}, {[cacheField]:fieldValues})
 		},
 
 		//Unset the cached field on the main collection if the matching doc on the target collection is removed
 		remove: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc');
-			debug(collection2._name+'.after.remove', doc._id);
+			debug('\n'+collection1._name+'.cacheDoc')
+			debug(collection2._name+'.after.remove', doc._id)
 
-			this.unset(getRealCollection(collection1, validate), object(referenceField, doc._id), [cacheField]);
+			this.unset(collection1, {[referenceField]:doc._id}, [cacheField])
 		},
-	});
+	})
 
 	autoUpdate(collection, [this._name, name, collection._name, fields, options])
 }

--- a/methods/cacheDoc.js
+++ b/methods/cacheDoc.js
@@ -13,10 +13,10 @@ import _ from 'lodash'
  *
  * When a document in the target collection is inserted/updated/removed this denormalization saves a copy of the document in the main collection. The reference field is on the main collection.
  */
-Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options) {
+Mongo.Collection.prototype.cacheDoc = function(name, childCollection, fields, options) {
 
 	check(name, String)
-	check(collection, Mongo.Collection)
+	check(childCollection, Mongo.Collection)
 	Match.test(fields, Match.OneOf([String], Object))
 	if(!Match.test(options, Object)) {
 		options = {}
@@ -25,8 +25,7 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 	if(Match.test(name, String)) {
 		_.defaults(options, {
 			cacheField: '_'+name,
-			referenceField: name+'_id',
-			helper: name,
+			referenceField: name+'_id'
 		})
 	}
 
@@ -41,16 +40,13 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 	check(options, {
 		cacheField: String,
 		referenceField: String,
-		helper: Match.Optional(String),
 		validate: Boolean,
 	})
 
 	let fieldsToCopy = _.isArray(fields) ? fields : flattenFields(fields)
 	let cacheField = options.cacheField
 	let referenceField = options.referenceField
-	let collection1 = this
-	let collection2 = collection
-	let helper = options.helper
+	let parentCollection = this
 	let validate = options.validate
 
 	//Fields specifier for Mongo.Collection.find
@@ -59,83 +55,102 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 		fieldsInFind[field] = 1
 	})
 
-	//Collection helper
-	if(helper && Match.test(collection1.helpers, Function)) {
-		let helpers = {}
-		helpers[helper] = function() {
-			let fieldValue = _.get(this, referenceField)
-			return fieldValue && collection2.findOne(fieldValue)
-		}
-		collection1.helpers(helpers)
-	}
-
-	Denormalize.addHooks(collection1, [referenceField], {
+	Denormalize.addHooks(parentCollection, [referenceField], {
 		//Update the cached field on the main collection after insert
-		insert: function(fieldValues, doc) {
+		insert: function(fieldValues, parent) {
 			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection1._name+'.after.insert', doc._id)
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(parentCollection._name+'.after.insert', parent._id)
 			debug('referenceField value:', referenceFieldValue)
 
-			let doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
-			if(doc2) {
-				debug('$set')
-				this.set(collection1, doc._id, {[cacheField]:doc2})
+			let cache
+			if(_.isArray(referenceFieldValue)){
+				cache = childCollection.find({_id:{$in:referenceFieldValue}}, {transform: null, fields: fieldsInFind}).fetch()
 			} else {
-				debug('$unset')
-				// No unset needed
+				cache = childCollection.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
+			}
+			if(cache) {
+				this.set(parentCollection, parent._id, {[cacheField]:cache})
 			}
 		},
 
 		//Update the cached field on the main collection if the referenceField field is changed
-		update: function(fieldValues, doc) {
+		update: function(fieldValues, parent) {
 			let referenceFieldValue = fieldValues[referenceField]
 
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection1._name+'.after.update', doc._id)
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(parentCollection._name+'.after.update', parent._id)
 			debug('referenceField value:', referenceFieldValue)
 
-			let doc2 = referenceFieldValue && collection2.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
-			if(doc2) {
-				debug('$set')
-				this.set(collection1, doc._id, {[cacheField]:doc2})
+			let cache
+			if(_.isArray(referenceFieldValue)){
+				cache = childCollection.find({_id:{$in:referenceFieldValue}}, {transform: null, fields: fieldsInFind}).fetch()
 			} else {
-				debug('$unset')
-				this.unset(collection1, doc._id, [cacheField])
+				cache = childCollection.findOne(referenceFieldValue, {transform: null, fields: fieldsInFind})
+			}
+			if(cache) {
+				this.set(parentCollection, parent._id, {[cacheField]:cache})
+			} else {
+				this.unset(parentCollection, parent._id, [cacheField])
 			}
 		},
 	})
 
-	Denormalize.addHooks(collection2, fieldsToCopy, {
+	Denormalize.addHooks(childCollection, fieldsToCopy, {
 		//Update the cached field on the main collection if a matching doc on the target collection is inserted
-		insert: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection2._name+'.after.insert', doc._id)
+		insert: function(fieldValues, child) {
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(childCollection._name+'.after.insert', child._id)
 			debug('fields to copy:', fieldsToCopy)
 			debug('changed fields:', fieldValues)
 
-			this.set(collection1, {[referenceField]:doc._id}, {[cacheField]:fieldValues})
+			parentCollection.find({[referenceField]:child._id}).forEach(parent => {
+				if(_.isArray(parent[referenceField])){
+					let index = parent[cacheField].length
+					this.set(parentCollection, parent._id, {[cacheField + '.' + index]:fieldValues})
+				} else {
+					this.set(parentCollection, parent._id, {[cacheField]:fieldValues})
+				}
+			})
 		},
 
 		//Update the cached field on the main collection if the matching doc on the target collection is updated
-		update: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection2._name+'.after.update', doc._id)
+		update: function(fieldValues, child) {
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(childCollection._name+'.after.update', child._id)
 			debug('fields to copy:', fieldsToCopy)
 			debug('changed fields:', fieldValues)
 
-			this.set(collection1, {[referenceField]:doc._id}, {[cacheField]:fieldValues})
+			parentCollection.find({[referenceField]:child._id}).forEach(parent => {
+				if(_.isArray(parent[referenceField])){
+					let index = _.findIndex(parent[cacheField], {_id:child._id})
+					if(index == -1){
+						index = parent[cacheField].length
+					}
+					this.set(parentCollection, parent._id, {[cacheField + '.' + index]:fieldValues})
+				} else {
+					this.set(parentCollection, parent._id, {[cacheField]:fieldValues})
+				}
+			})
 		},
 
 		//Unset the cached field on the main collection if the matching doc on the target collection is removed
-		remove: function(fieldValues, doc) {
-			debug('\n'+collection1._name+'.cacheDoc')
-			debug(collection2._name+'.after.remove', doc._id)
+		remove: function(fieldValues, child) {
+			debug('\n'+parentCollection._name+'.cacheDoc')
+			debug(childCollection._name+'.after.remove', child._id)
 
-			this.unset(collection1, {[referenceField]:doc._id}, [cacheField])
+			parentCollection.find({[referenceField]:child._id}).forEach(parent => {
+				if(_.isArray(parent[referenceField])){
+					let index = _.findIndex(parent[cacheField], {_id:child._id})
+					if(index !== -1){
+						this.unset(parentCollection, parent._id, {[cacheField + '.' + index]:1})
+					}
+				} else {
+					this.unset(parentCollection, parent._id, {[cacheField]:1})
+				}
+			})
 		},
 	})
-
-	autoUpdate(collection, [this._name, name, collection._name, fields, options])
+	autoUpdate(this, [name, childCollection._name, fields, options])
 }

--- a/methods/cacheDoc.js
+++ b/methods/cacheDoc.js
@@ -136,4 +136,5 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 		},
 	});
 
+	autoUpdate(collection, [this._name, name, collection._name, fields, options])
 }

--- a/methods/cacheDoc.js
+++ b/methods/cacheDoc.js
@@ -16,8 +16,7 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 
 	check(name, String);
 	check(collection, Mongo.Collection);
-	check(fields, [String]);
-
+	Match.test(fields, Match.OneOf([String], Object))
 	if(!Match.test(options, Object)) {
 		options = {};
 	}
@@ -45,7 +44,7 @@ Mongo.Collection.prototype.cacheDoc = function(name, collection, fields, options
 		validate: Boolean,
 	});
 
-	var fieldsToCopy = fields;
+	var fieldsToCopy = typeof fields == 'array' ? fields : flattenFields(fields);
 	var cacheField = options.cacheField;
 	var referenceField = options.referenceField;
 	var collection1 = this;

--- a/methods/cacheField.js
+++ b/methods/cacheField.js
@@ -63,4 +63,5 @@ Mongo.Collection.prototype.cacheField = function(cacheField, fields, value, opti
 		},
 	});
 
+	autoUpdate(this, [cacheField, fields, value, options])
 }

--- a/methods/cacheField.js
+++ b/methods/cacheField.js
@@ -33,36 +33,35 @@ Mongo.Collection.prototype.cacheField = function(cacheField, fields, callback, o
 	})
 
 	let validate = options.validate
-	let collection1 = this
+	let collection = this
 
-	Denormalize.addHooks(collection1, fields, {
+	Denormalize.addHooks(collection, fields, {
 		//Update the cached field after insert
 		insert: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheField')
-			debug(collection1._name+'.after.insert', doc._id)
+			debug('\n'+collection._name+'.cacheField')
+			debug(collection._name+'.after.insert', doc._id)
 
 			let val = callback(doc, fields)
 
 			if(val !== undefined) {
-				this.set(collection1, doc._id, {[cacheField]:val})
+				this.set(collection, doc._id, {[cacheField]:val})
 			}
 		},
 		//Update the cached field if any of the watched fields are changed
 		update: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheField')
-			debug(collection1._name+'.after.update', doc._id)
+			debug('\n'+collection._name+'.cacheField')
+			debug(collection._name+'.after.update', doc._id)
 
 			let val = callback(doc, fields)
 
 			if(val !== undefined) {
-				this.set(collection1, doc._id, {[cacheField]:val})
+				this.set(collection, doc._id, {[cacheField]:val})
 			} else {
-				this.unset(collection1, doc._id, [cacheField])
+				this.unset(collection, doc._id, [cacheField])
 			}
 		},
 	})
-
 	autoUpdate(this, [cacheField, fields, callback, options])
 }

--- a/methods/cacheField.js
+++ b/methods/cacheField.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 /**
  * @method collection.cacheField
  * @public
@@ -10,58 +11,58 @@
  *
  * When a document in the collection is inserted/updated this denormalization updates the cached field with a value based on the same document
  */
-Mongo.Collection.prototype.cacheField = function(cacheField, fields, value, options) {
-	if(value === undefined) {
-		value = Denormalize.fieldsJoiner();
+Mongo.Collection.prototype.cacheField = function(cacheField, fields, callback, options) {
+	if(!callback) {
+		callback = array => _.compact(array).join(', ')
 	}
 
-	check(fields, [String]);
-	check(cacheField, String);
-	check(value, Function);
+	check(fields, [String])
+	check(cacheField, String)
+	check(callback, Function)
 
 	if(!Match.test(options, Object)) {
-		options = {};
+		options = {}
 	}
 
 	_.defaults(options, {
 		validate: false,
-	});
+	})
 
 	check(options, {
 		validate: Boolean,
-	});
+	})
 
-	var validate = options.validate;
-	var collection1 = this;
+	let validate = options.validate
+	let collection1 = this
 
 	Denormalize.addHooks(collection1, fields, {
 		//Update the cached field after insert
 		insert: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheField');
-			debug(collection1._name+'.after.insert', doc._id);
+			debug('\n'+collection1._name+'.cacheField')
+			debug(collection1._name+'.after.insert', doc._id)
 
-			var val = value(doc, fields);
+			let val = callback(doc, fields)
 
 			if(val !== undefined) {
-				this.set(getRealCollection(collection1, validate), doc._id, object(cacheField, val))
+				this.set(collection1, doc._id, {[cacheField]:val})
 			}
 		},
 		//Update the cached field if any of the watched fields are changed
 		update: function(fieldValues, doc) {
 
-			debug('\n'+collection1._name+'.cacheField');
-			debug(collection1._name+'.after.update', doc._id);
+			debug('\n'+collection1._name+'.cacheField')
+			debug(collection1._name+'.after.update', doc._id)
 
-			var val = value(doc, fields);
+			let val = callback(doc, fields)
 
 			if(val !== undefined) {
-				this.set(getRealCollection(collection1, validate), doc._id, object(cacheField, val))
+				this.set(collection1, doc._id, {[cacheField]:val})
 			} else {
-				this.unset(getRealCollection(collection1, validate), doc._id, [cacheField])
+				this.unset(collection1, doc._id, [cacheField])
 			}
 		},
-	});
+	})
 
-	autoUpdate(this, [cacheField, fields, value, options])
+	autoUpdate(this, [cacheField, fields, callback, options])
 }

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'jeanfredrik:denormalize',
-  version: '0.7.2',
+  name: 'herteby:denormalize',
+  version: '0.8.0',
   summary: 'Provides simple methods for common denormalization tasks',
-  git: 'https://github.com/jeanfredrik/meteor-denormalize.git',
+  git: 'https://github.com/herteby/meteor-denormalize.git',
   documentation: 'README.md'
 })
 
@@ -10,11 +10,10 @@ Package.onUse(function(api) {
   api.versionsFrom('1.0')
 
   //Required core packages
+  api.use(['ecmascript'])
   api.use([
-    'ecmascript',
     'check',
     'mongo',
-    'underscore',
     'ejson'
   ], 'server')
 
@@ -45,7 +44,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use('tinytest')
-  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore', 'ejson'])
+  api.use(['check', 'mongo', 'autopublish', 'insecure', 'ejson'])
 
   //Weak 3rd party packages
   api.use([
@@ -53,7 +52,7 @@ Package.onTest(function(api) {
     'aldeed:collection2@2.0.0',
   ])
 
-  api.use('jeanfredrik:denormalize')
+  api.use('herteby:denormalize')
 
   api.export(['Posts', 'Comments', 'Denormalize'])
 

--- a/package.js
+++ b/package.js
@@ -4,54 +4,59 @@ Package.describe({
   summary: 'Provides simple methods for common denormalization tasks',
   git: 'https://github.com/jeanfredrik/meteor-denormalize.git',
   documentation: 'README.md'
-});
+})
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.0');
+  api.versionsFrom('1.0')
 
   //Required core packages
   api.use([
+    'ecmascript',
     'check',
     'mongo',
     'underscore',
     'ejson'
-  ], 'server');
+  ], 'server')
 
   //Required 3rd party packages
   api.use([
     'matb33:collection-hooks@0.7.13',
-  ], 'server');
+  ], 'server')
 
   //Weak 3rd party packages
   api.use([
     'dburles:collection-helpers@1.0.0',
     'aldeed:collection2@2.0.0',
-  ], {where: 'server', weak: true});
+  ], {where: 'server', weak: true})
 
-  api.addFiles('denormalize-common.js');
-  api.addFiles('denormalize-hooks.js', 'server');
+  Npm.depends({
+    "lodash": "4.17.4"
+  })
 
-  api.addFiles('methods/cacheDoc.js', 'server');
-  api.addFiles('methods/cacheCount.js', 'server');
-  api.addFiles('methods/cacheField.js', 'server');
+  api.addFiles('denormalize-common.js')
+  api.addFiles('denormalize-hooks.js', 'server')
 
-  api.export(['Denormalize']);
-});
+  api.addFiles('methods/cacheDoc.js', 'server')
+  api.addFiles('methods/cacheCount.js', 'server')
+  api.addFiles('methods/cacheField.js', 'server')
+
+  api.export(['Denormalize'])
+})
 
 Package.onTest(function(api) {
-  api.use('tinytest');
-  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore', 'ejson']);
+  api.use('tinytest')
+  api.use(['check', 'mongo', 'autopublish', 'insecure', 'underscore', 'ejson'])
 
   //Weak 3rd party packages
   api.use([
     'dburles:collection-helpers@1.0.0',
     'aldeed:collection2@2.0.0',
-  ]);
+  ])
 
-  api.use('jeanfredrik:denormalize');
+  api.use('jeanfredrik:denormalize')
 
-  api.export(['Posts', 'Comments', 'Denormalize']);
+  api.export(['Posts', 'Comments', 'Denormalize'])
 
-  api.addFiles('test-utils.js', 'server');
-  api.addFiles('denormalize-tests-server.js', 'server');
-});
+  api.addFiles('test-utils.js', 'server')
+  api.addFiles('denormalize-tests-server.js', 'server')
+})


### PR DESCRIPTION
Previously, if you tried using nested fields with cacheDoc (like this: `['profile.first_name','profile.last_name']`), Mongo would give an error, because $set ended up looking like this:
```
$set:{
  _user:{
    'profile.first_name':'Simon',
    'profile.last_name':'Herteby'
  }
}
```
Now it's correct:
```
$set:{
  _user:{
    profile:{
      first_name:'Simon',
      last_name:'Herteby'
    }
  }
}
```